### PR TITLE
Update jquery.fs.picker.js

### DIFF
--- a/jquery.fs.picker.js
+++ b/jquery.fs.picker.js
@@ -170,7 +170,7 @@ if (jQuery) (function($) {
 	function _onSelect(e) {
 		var data = e.data;
 		
-		if (typeof data.group !== "undefined") {
+		if (typeof data.group !== "undefined" && data.isRadio) {
 			$('input[name="' + data.group + '"]').not(data.$input).trigger("deselect");
 		}
 		


### PR DESCRIPTION
Fix for situation, when checkboxes has one name (e.g. "sample[ids][]") for getting values as array
