### PR TITLE
Fix for iOS6 on iPad 1

### DIFF
--- a/jquery.fs.picker.css
+++ b/jquery.fs.picker.css
@@ -7,7 +7,7 @@
  * Released under the MIT License <http://www.opensource.org/licenses/mit-license.php>
  */
  
- 	.picker-element { left: -999999px; position: absolute; }
+ 	.picker-element { left: -9999px; position: absolute; }
 	.picker { cursor: pointer; margin: 0 0 10px 0; overflow: hidden; }
 	.picker .picker-label { color: #888; display: block; float: left; font-size: 14px; float: left; line-height: 16px; 
 		-webkit-user-select: none;


### PR DESCRIPTION
-99999px caused some weird rendering issues on iPad 1 with iOS6. Lowering this value fixed this.
