### PR TITLE
Fix for IE8 compatibility issue

### DIFF
--- a/src/jquery.fs.picker.js
+++ b/src/jquery.fs.picker.js
@@ -193,7 +193,7 @@
 			// Bind click events
 			data.$input.on("focus.picker", data, _onFocus)
 					   .on("blur.picker", data, _onBlur)
-					   .on("change.picker", data, _onChange)
+					   .on((isIE8 ? "property": "") + "change.picker", data, _onChange)
 					   .on("click.picker", data, _onClick)
 					   .on("deselect.picker", data, _onDeselect)
 					   .data("picker", data);


### PR DESCRIPTION
IE8 does not support the standard change event for radios/checkboxes, it uses `propertychange` instead ([see here for more explanations](http://technoesis.net/jquery-change-event-firing-properly-ie/)). So when clicking a picker checkbox in IE, nothing happens. This patch fixes the change event for IE8 so checkboxes become clickable.

I'm not sure about formstone support for even older IEs? Since there already was a check for IE8 I used that, but older IEs will very likely need this fix, too!
